### PR TITLE
Add #6: Switch screen panel to VideoSurfacePanelRegistration

### DIFF
--- a/app/src/main/java/com/quest/jellyquest/JellyQuestActivity.kt
+++ b/app/src/main/java/com/quest/jellyquest/JellyQuestActivity.kt
@@ -32,15 +32,19 @@ import com.meta.spatial.runtime.ButtonBits
 import com.meta.spatial.toolkit.AppSystemActivity
 import com.meta.spatial.toolkit.DpPerMeterDisplayOptions
 import com.meta.spatial.toolkit.Material
+import com.meta.spatial.toolkit.MediaPanelRenderOptions
+import com.meta.spatial.toolkit.MediaPanelSettings
 import com.meta.spatial.toolkit.Mesh
 import com.meta.spatial.toolkit.MeshCollision
 import com.meta.spatial.toolkit.PanelInputOptions
 import com.meta.spatial.toolkit.PanelRegistration
 import com.meta.spatial.toolkit.PanelStyleOptions
+import com.meta.spatial.toolkit.PixelDisplayOptions
 import com.meta.spatial.toolkit.QuadShapeOptions
 import com.meta.spatial.toolkit.Box
 import com.meta.spatial.toolkit.Transform
 import com.meta.spatial.toolkit.UIPanelSettings
+import com.meta.spatial.toolkit.VideoSurfacePanelRegistration
 import com.meta.spatial.toolkit.createPanelEntity
 import com.meta.spatial.vr.VRFeature
 import com.quest.jellyquest.streaming.AuthState
@@ -76,6 +80,7 @@ class JellyQuestActivity : AppSystemActivity() {
   val currentScreen: State<ScreenConfig> get() = derivedStateOf { theaterState.value.screen }
 
   private var screenEntity: Entity? = null
+  private var screenOverlayEntity: Entity? = null
   private var browsePanelEntity: Entity? = null
   val browsePanelVisible = mutableStateOf(false)
   private var skyboxEntity: Entity? = null
@@ -228,11 +233,18 @@ class JellyQuestActivity : AppSystemActivity() {
             R.id.screen_panel,
             Transform(pose),
         )
+    screenOverlayEntity =
+        Entity.createPanelEntity(
+            R.id.screen_overlay_panel,
+            Transform(pose),
+        )
   }
 
   private fun respawnScreen() {
     screenEntity?.destroy()
     screenEntity = null
+    screenOverlayEntity?.destroy()
+    screenOverlayEntity = null
     spawnScreen()
   }
 
@@ -356,9 +368,27 @@ class JellyQuestActivity : AppSystemActivity() {
 
   override fun registerPanels(): List<PanelRegistration> {
     return listOf(
-        // Main screen panel
-        ComposeViewPanelRegistration(
+        // Main screen panel — direct-to-surface video rendering via compositor layer.
+        // ExoPlayer renders directly to the surface provided by the SDK, bypassing the
+        // Android View system for significantly sharper video output.
+        VideoSurfacePanelRegistration(
             R.id.screen_panel,
+            surfaceConsumer = { _, surface ->
+              exoPlayerSource.attachSurface(surface)
+            },
+            settingsCreator = {
+              val screen = theaterState.value.screen
+              MediaPanelSettings(
+                  shape = QuadShapeOptions(width = screen.widthM, height = screen.heightM),
+                  display = PixelDisplayOptions(width = 1920, height = 1080),
+                  rendering = MediaPanelRenderOptions(isDRM = false, zIndex = 0),
+                  style = PanelStyleOptions(themeResourceId = R.style.PanelAppThemeTransparent),
+              )
+            },
+        ),
+        // Screen overlay panel — transparent Compose layer for status text (paused, connecting, etc.)
+        ComposeViewPanelRegistration(
+            R.id.screen_overlay_panel,
             composeViewCreator = { _, ctx ->
               ComposeView(ctx).apply {
                 setContent {
@@ -371,7 +401,6 @@ class JellyQuestActivity : AppSystemActivity() {
             },
             settingsCreator = {
               val screen = theaterState.value.screen
-              // Scale density inversely with panel width to keep texture allocation reasonable.
               val baseDpPerMeter = 600f
               val referencePanelWidth = 1.44f // 65" TV as baseline
               val dpPerMeter = (baseDpPerMeter * referencePanelWidth / screen.widthM).coerceIn(40f, baseDpPerMeter)

--- a/app/src/main/java/com/quest/jellyquest/MonitorPanel.kt
+++ b/app/src/main/java/com/quest/jellyquest/MonitorPanel.kt
@@ -1,15 +1,11 @@
 package com.quest.jellyquest
 
-import android.view.SurfaceHolder
-import android.view.SurfaceView
-import android.view.ViewGroup
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -17,14 +13,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.viewinterop.AndroidView
 import com.meta.spatial.uiset.theme.SpatialTheme
 import com.quest.jellyquest.streaming.ConnectionState
 import com.quest.jellyquest.streaming.StreamSource
 
 /**
- * Main monitor composable. When a StreamSource is active and connected,
- * renders video via a SurfaceView. Otherwise falls back to HelloPanel.
+ * Overlay panel composable layered on top of the VideoSurfacePanelRegistration screen.
+ * Renders status text (paused, connecting, error) over the video, and falls back to
+ * HelloPanel when disconnected. Transparent when video is actively playing.
  */
 @Composable
 fun MonitorPanel(
@@ -55,62 +51,31 @@ fun MonitorPanel(
                 )
             }
         }
-        ConnectionState.PLAYING,
+        ConnectionState.PLAYING -> {
+            // Transparent — video from the screen panel shows through
+        }
         ConnectionState.PAUSED -> {
-            Box(modifier = Modifier.fillMaxSize().background(Color.Black)) {
-                // SurfaceView for VLC rendering
-                AndroidView(
-                    factory = { ctx ->
-                        SurfaceView(ctx).apply {
-                            layoutParams = ViewGroup.LayoutParams(
-                                ViewGroup.LayoutParams.MATCH_PARENT,
-                                ViewGroup.LayoutParams.MATCH_PARENT,
-                            )
-                            holder.addCallback(object : SurfaceHolder.Callback {
-                                override fun surfaceCreated(holder: SurfaceHolder) {
-                                    streamSource.attachSurface(holder.surface)
-                                }
-                                override fun surfaceChanged(holder: SurfaceHolder, format: Int, width: Int, height: Int) {}
-                                override fun surfaceDestroyed(holder: SurfaceHolder) {
-                                    streamSource.detachSurface()
-                                }
-                            })
-                        }
-                    },
-                    modifier = Modifier.fillMaxSize(),
-                )
-
-                // Overlay: media info when paused
-                if (state == ConnectionState.PAUSED) {
-                    Box(
-                        modifier = Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.5f)),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        Text(
-                            text = "Paused",
-                            style = SpatialTheme.typography.headline1Strong,
-                            color = Color.White,
-                        )
-                    }
+            Box(modifier = Modifier.fillMaxSize()) {
+                // Semi-transparent overlay so paused video is still visible beneath
+                Box(
+                    modifier = Modifier.fillMaxSize().background(Color.Black.copy(alpha = 0.5f)),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = "Paused",
+                        style = SpatialTheme.typography.headline1Strong,
+                        color = Color.White,
+                    )
                 }
 
-                // Media title overlay at bottom (only when paused)
-                if (state == ConnectionState.PAUSED) {
-                    info?.let { mediaInfo ->
-                        Text(
-                            text = "${mediaInfo.title} (${mediaInfo.width}x${mediaInfo.height})",
-                            style = SpatialTheme.typography.body2,
-                            color = Color.White.copy(alpha = 0.6f),
-                            modifier = Modifier.align(Alignment.BottomStart).padding(16.dp),
-                        )
-                    }
-                }
-            }
-
-            // Cleanup when composable leaves composition
-            DisposableEffect(streamSource) {
-                onDispose {
-                    streamSource.detachSurface()
+                // Media title and resolution at bottom
+                info?.let { mediaInfo ->
+                    Text(
+                        text = "${mediaInfo.title} (${mediaInfo.width}x${mediaInfo.height})",
+                        style = SpatialTheme.typography.body2,
+                        color = Color.White.copy(alpha = 0.6f),
+                        modifier = Modifier.align(Alignment.BottomStart).padding(16.dp),
+                    )
                 }
             }
         }

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <resources>
   <item type="id" name="screen_panel" />
+  <item type="id" name="screen_overlay_panel" />
   <item type="id" name="browse_panel" />
 </resources>


### PR DESCRIPTION
## Summary
- Replace `ComposeViewPanelRegistration` with `VideoSurfacePanelRegistration` for the screen panel so ExoPlayer renders directly to a compositor layer surface, bypassing the Android View system for sharper video
- Repurpose `MonitorPanel` as a transparent overlay on a separate `screen_overlay_panel` for status UI (paused, connecting, error, disconnected)

## Changes
- **JellyQuestActivity.kt**: New `VideoSurfacePanelRegistration` with `MediaPanelSettings`/`PixelDisplayOptions`, overlay panel registration, overlay entity lifecycle management
- **MonitorPanel.kt**: Removed SurfaceView/AndroidView, now overlay-only with transparent PLAYING state
- **ids.xml**: Added `screen_overlay_panel` ID

## Testing
- [x] Unit tests pass
- [x] Debug build succeeds
- [x] Deployed and verified on Quest 3

Fixes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)