### PR TITLE
Add #9: Fit video panel to content aspect ratio

### DIFF
--- a/app/src/main/java/com/quest/jellyquest/JellyQuestActivity.kt
+++ b/app/src/main/java/com/quest/jellyquest/JellyQuestActivity.kt
@@ -91,6 +91,11 @@ class JellyQuestActivity : AppSystemActivity() {
   lateinit var jellyfinClient: JellyfinClient
   private lateinit var playbackReporter: PlaybackReporter
 
+  // Current video dimensions for aspect-ratio fitting. Updated when ExoPlayer
+  // reports a new video size; triggers screen respawn so the panel reshapes.
+  private var videoWidth: Int = 0
+  private var videoHeight: Int = 0
+
   // Anchor: immutable snapshot of the user's position and facing direction.
   // Captured at startup and on recenter. All placement is relative to this point.
   private var anchor: Anchor? = null
@@ -120,6 +125,20 @@ class JellyQuestActivity : AppSystemActivity() {
         scope = activityScope,
     )
     Log.i(TAG, "ExoPlayer, Jellyfin client, and playback reporter initialized")
+
+    // Reshape screen panel when video dimensions change (aspect-ratio masking)
+    activityScope.launch {
+      exoPlayerSource.mediaInfo.collect { info ->
+        val w = info?.width ?: 0
+        val h = info?.height ?: 0
+        if (w > 0 && h > 0 && (w != videoWidth || h != videoHeight)) {
+          videoWidth = w
+          videoHeight = h
+          Log.i(TAG, "Video size changed to ${w}x${h}, reshaping screen panel")
+          respawnScreen()
+        }
+      }
+    }
 
     // Pre-fetch library content if already authenticated from saved credentials
     if (jellyfinClient.authState.value == AuthState.AUTHENTICATED) {
@@ -378,9 +397,12 @@ class JellyQuestActivity : AppSystemActivity() {
             },
             settingsCreator = {
               val screen = theaterState.value.screen
+              val (fitW, fitH) = fitVideoToScreen(screen.widthM, screen.heightM, videoWidth, videoHeight)
+              val pixW = if (videoWidth > 0) videoWidth else 1920
+              val pixH = if (videoHeight > 0) videoHeight else 1080
               MediaPanelSettings(
-                  shape = QuadShapeOptions(width = screen.widthM, height = screen.heightM),
-                  display = PixelDisplayOptions(width = 1920, height = 1080),
+                  shape = QuadShapeOptions(width = fitW, height = fitH),
+                  display = PixelDisplayOptions(width = pixW, height = pixH),
                   rendering = MediaPanelRenderOptions(isDRM = false, zIndex = 0),
                   style = PanelStyleOptions(themeResourceId = R.style.PanelAppThemeTransparent),
               )
@@ -401,11 +423,12 @@ class JellyQuestActivity : AppSystemActivity() {
             },
             settingsCreator = {
               val screen = theaterState.value.screen
+              val (fitW, fitH) = fitVideoToScreen(screen.widthM, screen.heightM, videoWidth, videoHeight)
               val baseDpPerMeter = 600f
               val referencePanelWidth = 1.44f // 65" TV as baseline
-              val dpPerMeter = (baseDpPerMeter * referencePanelWidth / screen.widthM).coerceIn(40f, baseDpPerMeter)
+              val dpPerMeter = (baseDpPerMeter * referencePanelWidth / fitW).coerceIn(40f, baseDpPerMeter)
               UIPanelSettings(
-                  shape = QuadShapeOptions(width = screen.widthM, height = screen.heightM),
+                  shape = QuadShapeOptions(width = fitW, height = fitH),
                   style = PanelStyleOptions(themeResourceId = R.style.PanelAppThemeTransparent),
                   display = DpPerMeterDisplayOptions(dpPerMeter),
                   input = PanelInputOptions(

--- a/app/src/main/java/com/quest/jellyquest/ScreenFit.kt
+++ b/app/src/main/java/com/quest/jellyquest/ScreenFit.kt
@@ -1,0 +1,34 @@
+package com.quest.jellyquest
+
+/**
+ * Compute the largest panel dimensions that fit within the screen bounds while
+ * preserving the video's native aspect ratio — like motorized masking in a
+ * premium theater that reshapes the screen for each film.
+ *
+ * @return Pair of (widthM, heightM) in world-space meters.
+ */
+fun fitVideoToScreen(
+    screenWidthM: Float,
+    screenHeightM: Float,
+    videoWidth: Int,
+    videoHeight: Int,
+): Pair<Float, Float> {
+    if (videoWidth <= 0 || videoHeight <= 0) {
+        return screenWidthM to screenHeightM
+    }
+
+    val videoAspect = videoWidth.toFloat() / videoHeight.toFloat()
+    val screenAspect = screenWidthM / screenHeightM
+
+    return if (videoAspect >= screenAspect) {
+        // Video is wider than screen — width-limited
+        val w = screenWidthM
+        val h = screenWidthM / videoAspect
+        w to h
+    } else {
+        // Video is narrower than screen — height-limited
+        val w = screenHeightM * videoAspect
+        val h = screenHeightM
+        w to h
+    }
+}

--- a/app/src/test/java/com/quest/jellyquest/ScreenFitTest.kt
+++ b/app/src/test/java/com/quest/jellyquest/ScreenFitTest.kt
@@ -1,0 +1,102 @@
+package com.quest.jellyquest
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ScreenFitTest {
+
+    // --- Aspect ratio matches screen bounds ---
+
+    @Test
+    fun `video matching screen aspect ratio uses full bounds`() {
+        // 2.39:1 video in 2.39:1 screen (14m x 5.86m)
+        val (w, h) = fitVideoToScreen(
+            screenWidthM = 14.0f, screenHeightM = 5.86f,
+            videoWidth = 2560, videoHeight = 1072,
+        )
+        assertEquals(14.0f, w, 0.01f)
+        assertEquals(5.86f, h, 0.01f)
+    }
+
+    // --- Video narrower than screen (height-limited) ---
+
+    @Test
+    fun `16x9 video in wide screen uses full height and narrower width`() {
+        // 16:9 (1.78:1) video in 2.39:1 screen
+        val (w, h) = fitVideoToScreen(
+            screenWidthM = 14.0f, screenHeightM = 5.86f,
+            videoWidth = 1920, videoHeight = 1080,
+        )
+        // Height-limited: full height 5.86m, width = 5.86 * (1920/1080) = 10.42m
+        assertEquals(10.42f, w, 0.01f)
+        assertEquals(5.86f, h, 0.01f)
+    }
+
+    // --- Video wider than screen (width-limited) ---
+
+    @Test
+    fun `ultra-wide video in 16x9 screen uses full width and shorter height`() {
+        // 2.39:1 video in a 16:9 screen (3.56m x 2.0m)
+        val (w, h) = fitVideoToScreen(
+            screenWidthM = 3.56f, screenHeightM = 2.0f,
+            videoWidth = 2560, videoHeight = 1072,
+        )
+        // Width-limited: full width 3.56m, height = 3.56 / (2560/1072) = 1.49m
+        assertEquals(3.56f, w, 0.01f)
+        assertEquals(1.49f, h, 0.01f)
+    }
+
+    // --- Square video ---
+
+    @Test
+    fun `square video in wide screen uses full height`() {
+        val (w, h) = fitVideoToScreen(
+            screenWidthM = 14.0f, screenHeightM = 5.86f,
+            videoWidth = 1080, videoHeight = 1080,
+        )
+        assertEquals(5.86f, w, 0.01f)
+        assertEquals(5.86f, h, 0.01f)
+    }
+
+    // --- IMAX tall format ---
+
+    @Test
+    fun `IMAX 1_43 video in wide screen uses full height`() {
+        // IMAX 1.43:1 in 2.39:1 screen
+        val (w, h) = fitVideoToScreen(
+            screenWidthM = 14.0f, screenHeightM = 5.86f,
+            videoWidth = 1430, videoHeight = 1000,
+        )
+        // Height-limited: full height, width = 5.86 * 1.43 = 8.38m
+        assertEquals(8.38f, w, 0.01f)
+        assertEquals(5.86f, h, 0.01f)
+    }
+
+    // --- Edge cases ---
+
+    @Test
+    fun `zero video dimensions returns screen bounds`() {
+        val (w, h) = fitVideoToScreen(
+            screenWidthM = 14.0f, screenHeightM = 5.86f,
+            videoWidth = 0, videoHeight = 0,
+        )
+        assertEquals(14.0f, w, 0.01f)
+        assertEquals(5.86f, h, 0.01f)
+    }
+
+    // --- Vertical centering ---
+
+    @Test
+    fun `fitted screen center Y accounts for reduced height`() {
+        // 16:9 in PLF: height shrinks from 5.86m to 10.42/1.78 ≈ doesn't apply
+        // Width-limited case: 2.39:1 in 16:9 screen, height = 1.49m
+        val (_, h) = fitVideoToScreen(
+            screenWidthM = 3.56f, screenHeightM = 2.0f,
+            videoWidth = 2560, videoHeight = 1072,
+        )
+        // Screen bottom at 1.2m (STAGE_HEIGHT), center = 1.2 + 1.49/2 = 1.945
+        val screenBottom = 1.2f
+        val centerY = screenBottom + h / 2f
+        assertEquals(1.945f, centerY, 0.01f)
+    }
+}


### PR DESCRIPTION
## Summary
- Add `fitVideoToScreen()` that computes the largest panel fitting within theater screen bounds while preserving the video's native aspect ratio — like motorized masking in premium theaters
- Respawn screen panel when video dimensions change so it reshapes to match content
- Set `PixelDisplayOptions` to native video resolution for 1:1 pixel rendering

## Changes
- **ScreenFit.kt**: Pure function for aspect-ratio-aware panel sizing
- **ScreenFitTest.kt**: 7 unit tests covering 16:9, scope, square, IMAX, and edge cases
- **JellyQuestActivity.kt**: Track video dimensions, collect `mediaInfo` changes, use fitted dimensions in both video and overlay panel settings

## Testing
- [x] Unit tests pass (7 new + existing)
- [x] Debug build succeeds
- [x] Deployed and verified on Quest 3

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)