### PR TITLE
Fix #15: Consistent progress indicators in browse panel

### DIFF
--- a/app/src/main/java/com/quest/jellyquest/BrowsePanel.kt
+++ b/app/src/main/java/com/quest/jellyquest/BrowsePanel.kt
@@ -372,7 +372,8 @@ private fun BrowseListItem(
     item: JellyfinItem,
     onClick: () -> Unit,
 ) {
-    val hasProgress = !item.isFolder && item.runTimeTicks > 0 && item.playbackPositionTicks > 0
+    val hasPosition = !item.isFolder && item.playbackPositionTicks > 0
+    val hasProgress = hasPosition && item.runTimeTicks > 0
     val fullyWatched = hasProgress && PlaybackReporter.isFullyWatched(
         item.playbackPositionTicks, item.runTimeTicks,
     )
@@ -420,6 +421,12 @@ private fun BrowseListItem(
                 Spacer(modifier = Modifier.size(8.dp))
                 Text(
                     text = "${remainingMin} min left",
+                    style = SpatialTheme.typography.body2.copy(color = DraculaOrange),
+                )
+            } else if (hasPosition && !hasProgress) {
+                Spacer(modifier = Modifier.size(8.dp))
+                Text(
+                    text = "In Progress",
                     style = SpatialTheme.typography.body2.copy(color = DraculaOrange),
                 )
             }

--- a/app/src/main/java/com/quest/jellyquest/streaming/JellyfinClient.kt
+++ b/app/src/main/java/com/quest/jellyquest/streaming/JellyfinClient.kt
@@ -398,6 +398,16 @@ class JellyfinClient(private val context: Context) {
                     ),
                 )
             }
+            // Update local cache so browse panel shows current progress without re-fetching.
+            val (updatedItems, updatedLibraries) = updateCachedItemPosition(
+                cachedItems = _cachedItems.value,
+                cachedLibraries = _cachedLibraries.value,
+                itemId = itemId,
+                positionTicks = positionTicks,
+            )
+            _cachedItems.value = updatedItems
+            _cachedLibraries.value = updatedLibraries
+            saveCacheToDisk(updatedLibraries ?: emptyList(), updatedItems)
             Log.i(TAG, "Reported playback stopped: $itemId at ${positionTicks / 10_000}ms")
         } catch (e: Exception) {
             Log.e(TAG, "Failed to report playback stopped", e)
@@ -471,4 +481,25 @@ class JellyfinClient(private val context: Context) {
         playbackPositionTicks = this.userData?.playbackPositionTicks ?: 0,
         runTimeTicks = this.runTimeTicks ?: 0,
     )
+}
+
+/**
+ * Pure function that returns updated cache maps with the given item's position replaced.
+ * Searches all library lists in [cachedItems] and [cachedLibraries] for the item by ID.
+ */
+fun updateCachedItemPosition(
+    cachedItems: Map<UUID, List<JellyfinItem>>,
+    cachedLibraries: List<JellyfinItem>?,
+    itemId: UUID,
+    positionTicks: Long,
+): Pair<Map<UUID, List<JellyfinItem>>, List<JellyfinItem>?> {
+    val updatedItems = cachedItems.mapValues { (_, items) ->
+        items.map { item ->
+            if (item.id == itemId) item.copy(playbackPositionTicks = positionTicks) else item
+        }
+    }
+    val updatedLibraries = cachedLibraries?.map { item ->
+        if (item.id == itemId) item.copy(playbackPositionTicks = positionTicks) else item
+    }
+    return updatedItems to updatedLibraries
 }

--- a/app/src/main/java/com/quest/jellyquest/streaming/PlaybackReporter.kt
+++ b/app/src/main/java/com/quest/jellyquest/streaming/PlaybackReporter.kt
@@ -120,7 +120,7 @@ class PlaybackReporter(
         /** Compute what percentage of the content has been watched (0-100). */
         fun computeProgressPercent(positionTicks: Long, runtimeTicks: Long): Int {
             if (runtimeTicks <= 0 || positionTicks <= 0) return 0
-            return (positionTicks * 100 / runtimeTicks).toInt().coerceIn(0, 100)
+            return (positionTicks * 100 / runtimeTicks).toInt().coerceIn(1, 100)
         }
 
         /** Compute how many minutes remain. */

--- a/app/src/test/java/com/quest/jellyquest/streaming/CacheUpdateTest.kt
+++ b/app/src/test/java/com/quest/jellyquest/streaming/CacheUpdateTest.kt
@@ -1,0 +1,115 @@
+package com.quest.jellyquest.streaming
+
+import org.jellyfin.sdk.model.api.BaseItemKind
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.util.UUID
+
+class CacheUpdateTest {
+
+    private val movieId = UUID.fromString("550e8400-e29b-41d4-a716-446655440000")
+    private val libraryId = UUID.fromString("660e8400-e29b-41d4-a716-446655440000")
+
+    private fun makeItem(
+        id: UUID = movieId,
+        name: String = "The Avengers",
+        positionTicks: Long = 0,
+        runTimeTicks: Long = 72_000_000_000L,
+    ) = JellyfinItem(
+        id = id,
+        name = name,
+        type = BaseItemKind.MOVIE,
+        isFolder = false,
+        playbackPositionTicks = positionTicks,
+        runTimeTicks = runTimeTicks,
+    )
+
+    @Test
+    fun `updateCachedItemPosition updates item in cached items map`() {
+        val original = makeItem(positionTicks = 0)
+        val cachedItems = mapOf(libraryId to listOf(original))
+
+        val (updatedItems, _) = updateCachedItemPosition(
+            cachedItems = cachedItems,
+            cachedLibraries = null,
+            itemId = movieId,
+            positionTicks = 36_000_000_000L,
+        )
+
+        val updatedItem = updatedItems[libraryId]!!.first()
+        assertEquals(36_000_000_000L, updatedItem.playbackPositionTicks)
+        // Other fields unchanged
+        assertEquals("The Avengers", updatedItem.name)
+        assertEquals(72_000_000_000L, updatedItem.runTimeTicks)
+    }
+
+    @Test
+    fun `updateCachedItemPosition returns unchanged maps when item not found`() {
+        val unrelatedId = UUID.fromString("770e8400-e29b-41d4-a716-446655440000")
+        val original = makeItem()
+        val cachedItems = mapOf(libraryId to listOf(original))
+
+        val (updatedItems, _) = updateCachedItemPosition(
+            cachedItems = cachedItems,
+            cachedLibraries = null,
+            itemId = unrelatedId,
+            positionTicks = 10_000_000_000L,
+        )
+
+        assertEquals(0L, updatedItems[libraryId]!!.first().playbackPositionTicks)
+    }
+
+    @Test
+    fun `updateCachedItemPosition updates item across multiple libraries`() {
+        val otherLibraryId = UUID.fromString("880e8400-e29b-41d4-a716-446655440000")
+        val item1 = makeItem(positionTicks = 0)
+        val item2 = makeItem(
+            id = UUID.fromString("990e8400-e29b-41d4-a716-446655440000"),
+            name = "Other Movie",
+        )
+        val cachedItems = mapOf(
+            libraryId to listOf(item1, item2),
+            otherLibraryId to listOf(item1.copy()),
+        )
+
+        val (updatedItems, _) = updateCachedItemPosition(
+            cachedItems = cachedItems,
+            cachedLibraries = null,
+            itemId = movieId,
+            positionTicks = 5_000_000_000L,
+        )
+
+        // Updated in first library
+        assertEquals(5_000_000_000L, updatedItems[libraryId]!!.first { it.id == movieId }.playbackPositionTicks)
+        // Updated in second library too
+        assertEquals(5_000_000_000L, updatedItems[otherLibraryId]!!.first { it.id == movieId }.playbackPositionTicks)
+        // Unrelated item untouched
+        assertEquals(0L, updatedItems[libraryId]!!.first { it.name == "Other Movie" }.playbackPositionTicks)
+    }
+
+    @Test
+    fun `updateCachedItemPosition updates cachedLibraries if item exists there`() {
+        val libraries = listOf(makeItem(positionTicks = 0))
+
+        val (_, updatedLibraries) = updateCachedItemPosition(
+            cachedItems = emptyMap(),
+            cachedLibraries = libraries,
+            itemId = movieId,
+            positionTicks = 20_000_000_000L,
+        )
+
+        assertEquals(20_000_000_000L, updatedLibraries!!.first().playbackPositionTicks)
+    }
+
+    @Test
+    fun `updateCachedItemPosition preserves null cachedLibraries`() {
+        val (_, updatedLibraries) = updateCachedItemPosition(
+            cachedItems = emptyMap(),
+            cachedLibraries = null,
+            itemId = movieId,
+            positionTicks = 10_000_000_000L,
+        )
+
+        assertEquals(null, updatedLibraries)
+    }
+}

--- a/app/src/test/java/com/quest/jellyquest/streaming/PlaybackReporterTest.kt
+++ b/app/src/test/java/com/quest/jellyquest/streaming/PlaybackReporterTest.kt
@@ -85,6 +85,14 @@ class PlaybackReporterTest {
     }
 
     @Test
+    fun `computeProgressPercent returns minimum 1 for tiny position`() {
+        // 30 seconds into a 2hr movie = 0.4%, should clamp to 1 not 0
+        val thirtySecondsTicks = 300_000_000L // 30s in ticks
+        val twoHoursTicks = 72_000_000_000L
+        assertEquals(1, PlaybackReporter.computeProgressPercent(thirtySecondsTicks, twoHoursTicks))
+    }
+
+    @Test
     fun `computeRemainingMinutes returns correct value`() {
         // 2hr movie, 30 min in -> 90 min remaining
         // 30 min = 18_000_000_000 ticks, 2hr = 72_000_000_000 ticks


### PR DESCRIPTION
## Summary
- Update local item cache when playback stops so browse panel shows current progress immediately
- Fix progress bar not rendering for < 1% positions (integer division rounding)
- Show "In Progress" fallback when runtime metadata is missing but position exists

## Root Cause
Browse panel served stale items cached at app launch. After watching a movie, `reportPlaybackStopped()` updated the server but not the local cache.

## Test plan
- [x] Unit tests: cache update, < 1% progress minimum, existing tests pass
- [x] On-device: watched movie, stopped, opened browse panel — progress indicator appeared correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)