### PR TITLE
Add #25: Replace procedural theater boxes with GLB environment

### DIFF
--- a/app/src/main/java/com/quest/jellyquest/JellyQuestActivity.kt
+++ b/app/src/main/java/com/quest/jellyquest/JellyQuestActivity.kt
@@ -88,6 +88,7 @@ class JellyQuestActivity : AppSystemActivity() {
   private var floorEntity: Entity? = null
   private var wallEntities: List<Entity> = emptyList()
   private var armrestEntities: List<Entity> = emptyList()
+  private var environmentModelEntity: Entity? = null
 
   // Jellyfin + ExoPlayer
   lateinit var exoPlayerSource: ExoPlayerSource
@@ -190,7 +191,7 @@ class JellyQuestActivity : AppSystemActivity() {
     scene.setReferenceSpace(ReferenceSpace.LOCAL_FLOOR)
 
     scene.setLightingEnvironment(
-        ambientColor = Vector3(0.05f),
+        ambientColor = Vector3(3.0f),
         sunColor = Vector3(0.0f, 0.0f, 0.0f),
         sunDirection = -Vector3(1.0f, 3.0f, -2.0f),
         environmentIntensity = 0.0f,
@@ -315,6 +316,10 @@ class JellyQuestActivity : AppSystemActivity() {
     browsePanelEntity = null
   }
 
+  private fun currentExperience(): TheaterExperience? {
+    return THEATER_EXPERIENCES.firstOrNull { it.name == theaterState.value.screen.label }
+  }
+
   private fun spawnEnvironment() {
     val a = anchor ?: return
     skyboxEntity?.destroy()
@@ -323,10 +328,13 @@ class JellyQuestActivity : AppSystemActivity() {
     wallEntities = emptyList()
     armrestEntities.forEach { it.destroy() }
     armrestEntities = emptyList()
+    environmentModelEntity?.destroy()
+    environmentModelEntity = null
 
     val envPos = TheaterLayout.environmentPosition(a)
     val screen = theaterState.value.screen
     val room = theaterState.value.room
+    val experience = currentExperience()
 
     // Skybox: near-black sphere centered on the user
     skyboxEntity = Entity.create(listOf(
@@ -338,6 +346,36 @@ class JellyQuestActivity : AppSystemActivity() {
         Transform(Pose(envPos)),
     ))
 
+    val asset = experience?.environmentAsset
+    if (asset != null) {
+      // GLB environment — baked 3D model replaces procedural walls, floor, and ceiling
+      val glbPose = TheaterLayout.glbEnvironmentPose(a, screen)
+      environmentModelEntity = Entity.create(listOf(
+          Mesh(asset.toUri(), hittable = MeshCollision.NoCollision),
+          Transform(Pose(glbPose.t, glbPose.q)),
+      ))
+      Log.i(TAG, "GLB environment loaded: $asset pos=${glbPose.t} rot=${glbPose.q}")
+      Log.i(TAG, "  Anchor pos=${a.position} fwd=${a.forward}")
+      Log.i(TAG, "  Model origin at screen wall, extends -Z toward viewer (30m deep)")
+      Log.i(TAG, "  Viewer should be ~${screen.distanceM}m from screen wall inside model")
+    } else {
+      // Procedural box environment — flat-colored walls, floor, and ceiling
+      spawnProceduralEnvironment(a, envPos, screen, room)
+    }
+
+    // Armrests: always SDK entities (viewer-relative positioning)
+    val c = TheaterEnvironment.colors
+    val armrestBox = Box(
+        Vector3(-ViewerLayout.ARMREST_WIDTH / 2f, -ViewerLayout.ARMREST_HEIGHT / 2f, -ViewerLayout.ARMREST_LENGTH / 2f),
+        Vector3(ViewerLayout.ARMREST_WIDTH / 2f, ViewerLayout.ARMREST_HEIGHT / 2f, ViewerLayout.ARMREST_LENGTH / 2f),
+    )
+    armrestEntities = listOf(
+        createBoxEntity(armrestBox, c.armrest, ViewerLayout.armrestPose(a, theaterState.value.riserHeightM, isLeft = true)),
+        createBoxEntity(armrestBox, c.armrest, ViewerLayout.armrestPose(a, theaterState.value.riserHeightM, isLeft = false)),
+    )
+  }
+
+  private fun spawnProceduralEnvironment(a: Anchor, envPos: Vector3, screen: ScreenConfig, room: RoomGeometry) {
     // Floor: dark charcoal ground plane centered on the user
     val floorHalfW = room.widthBack / 2f
     val floorHalfD = room.depth / 2f
@@ -353,7 +391,6 @@ class JellyQuestActivity : AppSystemActivity() {
 
     // Walls and ceiling
     val wallLength = TheaterLayout.wallLength(screen, room)
-    val halfH = room.ceilingHeight / 2f
     val t = TheaterEnvironment.WALL_THICKNESS
 
     // Screen wall splits around the screen opening — left flank, right flank, and top strip
@@ -412,16 +449,6 @@ class JellyQuestActivity : AppSystemActivity() {
             c.ceiling,
             TheaterLayout.ceilingPose(a, screen, room),
         ),
-    )
-
-    // Armrests
-    val armrestBox = Box(
-        Vector3(-ViewerLayout.ARMREST_WIDTH / 2f, -ViewerLayout.ARMREST_HEIGHT / 2f, -ViewerLayout.ARMREST_LENGTH / 2f),
-        Vector3(ViewerLayout.ARMREST_WIDTH / 2f, ViewerLayout.ARMREST_HEIGHT / 2f, ViewerLayout.ARMREST_LENGTH / 2f),
-    )
-    armrestEntities = listOf(
-        createBoxEntity(armrestBox, c.armrest, ViewerLayout.armrestPose(a, theaterState.value.riserHeightM, isLeft = true)),
-        createBoxEntity(armrestBox, c.armrest, ViewerLayout.armrestPose(a, theaterState.value.riserHeightM, isLeft = false)),
     )
   }
 

--- a/app/src/main/java/com/quest/jellyquest/JellyQuestActivity.kt
+++ b/app/src/main/java/com/quest/jellyquest/JellyQuestActivity.kt
@@ -363,16 +363,18 @@ class JellyQuestActivity : AppSystemActivity() {
       spawnProceduralEnvironment(a, envPos, screen, room)
     }
 
-    // Armrests: always SDK entities (viewer-relative positioning)
-    val c = TheaterEnvironment.colors
-    val armrestBox = Box(
-        Vector3(-ViewerLayout.ARMREST_WIDTH / 2f, -ViewerLayout.ARMREST_HEIGHT / 2f, -ViewerLayout.ARMREST_LENGTH / 2f),
-        Vector3(ViewerLayout.ARMREST_WIDTH / 2f, ViewerLayout.ARMREST_HEIGHT / 2f, ViewerLayout.ARMREST_LENGTH / 2f),
-    )
-    armrestEntities = listOf(
-        createBoxEntity(armrestBox, c.armrest, ViewerLayout.armrestPose(a, theaterState.value.riserHeightM, isLeft = true)),
-        createBoxEntity(armrestBox, c.armrest, ViewerLayout.armrestPose(a, theaterState.value.riserHeightM, isLeft = false)),
-    )
+    // Armrests: only for procedural environments (GLB model has its own)
+    if (asset == null) {
+      val c = TheaterEnvironment.colors
+      val armrestBox = Box(
+          Vector3(-ViewerLayout.ARMREST_WIDTH / 2f, -ViewerLayout.ARMREST_HEIGHT / 2f, -ViewerLayout.ARMREST_LENGTH / 2f),
+          Vector3(ViewerLayout.ARMREST_WIDTH / 2f, ViewerLayout.ARMREST_HEIGHT / 2f, ViewerLayout.ARMREST_LENGTH / 2f),
+      )
+      armrestEntities = listOf(
+          createBoxEntity(armrestBox, c.armrest, ViewerLayout.armrestPose(a, theaterState.value.riserHeightM, isLeft = true)),
+          createBoxEntity(armrestBox, c.armrest, ViewerLayout.armrestPose(a, theaterState.value.riserHeightM, isLeft = false)),
+      )
+    }
   }
 
   private fun spawnProceduralEnvironment(a: Anchor, envPos: Vector3, screen: ScreenConfig, room: RoomGeometry) {

--- a/app/src/main/java/com/quest/jellyquest/TheaterExperiences.kt
+++ b/app/src/main/java/com/quest/jellyquest/TheaterExperiences.kt
@@ -8,7 +8,10 @@ data class TheaterExperience(
     val screenBottomM: Float = STAGE_HEIGHT,
     val ceilingHeightM: Float,
     val seats: List<SeatPosition>,
-)
+    val environmentAsset: String? = null,
+) {
+    val hasGlbEnvironment: Boolean get() = environmentAsset != null
+}
 
 data class SeatPosition(
     val label: String,
@@ -38,10 +41,11 @@ val THEATER_EXPERIENCES = listOf(
         screenHeightM = 5.0f,
         ceilingHeightM = 10.0f,
         seats = listOf(
-            SeatPosition("Front", 11.42f, riserHeightM = 0.0f),
-            SeatPosition("Middle", 14.63f, riserHeightM = 0.68f),
-            SeatPosition("Back", 18.91f, riserHeightM = 1.60f),
+            SeatPosition("Front", 11.42f, riserHeightM = 1.60f),
+            SeatPosition("Middle", 14.63f, riserHeightM = 2.08f),
+            SeatPosition("Back", 18.91f, riserHeightM = 2.71f),
         ),
+        environmentAsset = "cinema_multiplex.glb",
     ),
     TheaterExperience(
         name = "Premium Large Format",

--- a/app/src/main/java/com/quest/jellyquest/TheaterExperiences.kt
+++ b/app/src/main/java/com/quest/jellyquest/TheaterExperiences.kt
@@ -41,9 +41,9 @@ val THEATER_EXPERIENCES = listOf(
         screenHeightM = 5.0f,
         ceilingHeightM = 10.0f,
         seats = listOf(
-            SeatPosition("Front", 11.42f, riserHeightM = 1.60f),
-            SeatPosition("Middle", 14.63f, riserHeightM = 2.08f),
-            SeatPosition("Back", 18.91f, riserHeightM = 2.71f),
+            SeatPosition("Front", 11.42f, riserHeightM = 1.55f),
+            SeatPosition("Middle", 14.63f, riserHeightM = 2.03f),
+            SeatPosition("Back", 18.91f, riserHeightM = 2.66f),
         ),
         environmentAsset = "cinema_multiplex.glb",
     ),

--- a/app/src/main/java/com/quest/jellyquest/TheaterLayout.kt
+++ b/app/src/main/java/com/quest/jellyquest/TheaterLayout.kt
@@ -73,7 +73,7 @@ object TheaterLayout {
      * rather than the aisle.
      */
     private const val GLB_SCREEN_WALL_OFFSET = 0.2f
-    private const val GLB_LATERAL_OFFSET = 0.55f  // shift model left so viewer sits in a seat
+    private const val GLB_LATERAL_OFFSET = 0.945f  // Seats_All translation (1.095) - fine-tune (0.15)
 
     fun glbEnvironmentPose(anchor: Anchor, screen: ScreenConfig): Pose {
         val xz = anchor.position +

--- a/app/src/main/java/com/quest/jellyquest/TheaterLayout.kt
+++ b/app/src/main/java/com/quest/jellyquest/TheaterLayout.kt
@@ -66,6 +66,22 @@ object TheaterLayout {
         return Pose(position, anchor.rotation)
     }
 
+    /**
+     * GLB environment model origin — at the screen wall surface, floor level.
+     * Offset behind the video panel so mesh geometry doesn't z-fight
+     * with the compositor layer. Lateral offset centers the viewer in a seat
+     * rather than the aisle.
+     */
+    private const val GLB_SCREEN_WALL_OFFSET = 0.2f
+    private const val GLB_LATERAL_OFFSET = 0.55f  // shift model left so viewer sits in a seat
+
+    fun glbEnvironmentPose(anchor: Anchor, screen: ScreenConfig): Pose {
+        val xz = anchor.position +
+            anchor.forward * (screen.distanceM + GLB_SCREEN_WALL_OFFSET) -
+            anchor.right * GLB_LATERAL_OFFSET
+        return Pose(Vector3(xz.x, 0f, xz.z), anchor.rotation)
+    }
+
     /** Wall length from screen wall to back wall. */
     fun wallLength(screen: ScreenConfig, room: RoomGeometry): Float {
         return screen.distanceM + room.backDistance

--- a/app/src/main/java/com/quest/jellyquest/TheaterState.kt
+++ b/app/src/main/java/com/quest/jellyquest/TheaterState.kt
@@ -17,12 +17,16 @@ data class ScreenConfig(
     val screenCenterY: Float get() = screenBottomM + (heightM / 2f)
 }
 
-/** Default screen: PLF middle seat. */
+/** Default theater preset and seat, used at startup before user selects. */
+private val DEFAULT_EXPERIENCE = THEATER_EXPERIENCES.first { it.name == "Multiplex" }
+private val DEFAULT_SEAT = DEFAULT_EXPERIENCE.seats.first { it.label == "Middle" }
+
 val DEFAULT_SCREEN = ScreenConfig(
-    label = "Premium Large Format",
-    widthM = 16.0f,
-    heightM = 6.69f,
-    distanceM = 22.0f,
+    label = DEFAULT_EXPERIENCE.name,
+    widthM = DEFAULT_EXPERIENCE.screenWidthM,
+    heightM = DEFAULT_EXPERIENCE.screenHeightM,
+    distanceM = DEFAULT_SEAT.distanceM,
+    screenBottomM = DEFAULT_EXPERIENCE.screenBottomM,
 )
 
 /**
@@ -31,6 +35,6 @@ val DEFAULT_SCREEN = ScreenConfig(
  */
 data class TheaterState(
     val screen: ScreenConfig = DEFAULT_SCREEN,
-    val riserHeightM: Float = 0f,
-    val room: RoomGeometry = TheaterEnvironment.computeRoom(THEATER_EXPERIENCES[2]),
+    val riserHeightM: Float = DEFAULT_SEAT.riserHeightM,
+    val room: RoomGeometry = TheaterEnvironment.computeRoom(DEFAULT_EXPERIENCE),
 )

--- a/app/src/test/java/com/quest/jellyquest/TheaterEnvironmentTest.kt
+++ b/app/src/test/java/com/quest/jellyquest/TheaterEnvironmentTest.kt
@@ -1,6 +1,10 @@
 package com.quest.jellyquest
 
+import com.meta.spatial.core.Quaternion
+import com.meta.spatial.core.Vector3
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -132,10 +136,84 @@ class TheaterEnvironmentTest {
 
     // --- Screen frame ---
 
+    // --- GLB environment positioning ---
+
+    @Test
+    fun `glb environment pose Y is at floor level`() {
+        val anchor = Anchor(
+            position = Vector3(5f, 0f, 3f),
+            forward = Vector3(0f, 0f, 1f),
+            rotation = Quaternion(0f, 0f, 0f),
+        )
+        val screen = ScreenConfig(label = "Multiplex", widthM = 12f, heightM = 5f, distanceM = 14.63f)
+
+        val pose = TheaterLayout.glbEnvironmentPose(anchor, screen)
+        assertEquals(0f, pose.t.y, 0.01f)
+    }
+
+    @Test
+    fun `glb environment pose uses anchor rotation`() {
+        val rotation = Quaternion(0f, 45f, 0f)
+        val anchor = Anchor(
+            position = Vector3(0f, 0f, 0f),
+            forward = Vector3(0.707f, 0f, 0.707f),
+            rotation = rotation,
+        )
+        val screen = ScreenConfig(label = "Multiplex", widthM = 12f, heightM = 5f, distanceM = 14.63f)
+
+        val pose = TheaterLayout.glbEnvironmentPose(anchor, screen)
+        assertEquals(rotation, pose.q)
+    }
+
     @Test
     fun `screen frame returns 4 boxes`() {
         val boxes = TheaterEnvironment.screenFrameBoxes(14.0f, 5.86f)
         assertEquals(4, boxes.size)
+    }
+
+    // --- GLB environment asset ---
+
+    @Test
+    fun `multiplex has environment asset`() {
+        val multiplex = THEATER_EXPERIENCES.first { it.name == "Multiplex" }
+        assertEquals("cinema_multiplex.glb", multiplex.environmentAsset)
+    }
+
+    @Test
+    fun `non-multiplex presets have null environment asset`() {
+        THEATER_EXPERIENCES.filter { it.name != "Multiplex" }.forEach { exp ->
+            assertNull("${exp.name} should not have environmentAsset", exp.environmentAsset)
+        }
+    }
+
+    @Test
+    fun `hasGlbEnvironment returns true only for multiplex`() {
+        THEATER_EXPERIENCES.forEach { exp ->
+            val expected = exp.name == "Multiplex"
+            assertEquals("${exp.name}: hasGlbEnvironment", expected, exp.hasGlbEnvironment)
+        }
+    }
+
+    @Test
+    fun `theater state screen label matches experience name for preset lookup`() {
+        THEATER_EXPERIENCES.forEach { exp ->
+            exp.seats.forEach { seat ->
+                val state = TheaterState(
+                    screen = ScreenConfig(
+                        label = exp.name,
+                        widthM = exp.screenWidthM,
+                        heightM = exp.screenHeightM,
+                        distanceM = seat.distanceM,
+                        screenBottomM = exp.screenBottomM,
+                    ),
+                    riserHeightM = seat.riserHeightM,
+                    room = TheaterEnvironment.computeRoom(exp),
+                )
+                val found = THEATER_EXPERIENCES.firstOrNull { it.name == state.screen.label }
+                assertNotNull("Should find experience for ${exp.name}", found)
+                assertEquals(exp.environmentAsset, found!!.environmentAsset)
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Replace procedural Box entities with baked `cinema_multiplex.glb` model for Multiplex theater preset
- Other presets (Screening Room, PLF, IMAX) retain procedural boxes as fallback
- Default theater changed from PLF to Multiplex (derived from preset data, no magic numbers)

## Changes
- **TheaterExperiences.kt**: Add `environmentAsset` field and `hasGlbEnvironment` property. Update Multiplex riser heights to match model's raked floor geometry.
- **TheaterLayout.kt**: Add `glbEnvironmentPose()` with z-fight offset and lateral seat alignment.
- **JellyQuestActivity.kt**: Branch `spawnEnvironment()` for GLB vs procedural. Skip fake armrests for GLB presets. Boost ambient light for lightmap visibility.
- **TheaterState.kt**: Default to Multiplex middle seat, derive all defaults from preset data.
- **TheaterEnvironmentTest.kt**: 6 new tests for GLB support, preset lookup, and positioning.
- **cinema_multiplex.glb**: Stripped Screen placeholder mesh to prevent compositor layer conflict.

## Testing
- [x] Unit tests pass (79 total, 6 new)
- [x] On-device testing on Quest 3 — seat position tuned iteratively
- [x] Video playback verified through GLB environment
- [x] Other presets still use procedural boxes (no regression)
- [x] Recenter repositions GLB correctly

## Known Issues
- Lightmaps are very dark (baked in cinema-dark mode) — tracked in #26
- Seat position fine-tuning may need per-seat lateral offsets in future

Fixes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)